### PR TITLE
Add Global Notification system to NexusFlag

### DIFF
--- a/app/api/v1/endpoints/admin.py
+++ b/app/api/v1/endpoints/admin.py
@@ -6,6 +6,8 @@ from app.core.db import get_db
 from app.models.challenge import Challenge
 from app.models.user import User
 from app.api.deps import get_current_admin_user
+from app.models.notification import Notification
+from app.schemas.notification import NotificationCreate, NotificationResponse
 
 router = APIRouter()
 
@@ -43,3 +45,19 @@ async def upload_challenge_file(
         "challenge_id": challenge_id,
         "status": "successfully uploaded"
     }
+
+@router.post("/notifications", response_model=NotificationResponse)
+def create_global_notification(
+    notification_in: NotificationCreate,
+    db: Session = Depends(get_db),
+    _admin_user: User = Depends(get_current_admin_user)
+):
+    """
+    Allows admins to broadcast a short notification to all players.
+    """
+    new_notification = Notification(content=notification_in.content.strip())
+    db.add(new_notification)
+    db.commit()
+    db.refresh(new_notification)
+    
+    return new_notification

--- a/app/api/v1/endpoints/game.py
+++ b/app/api/v1/endpoints/game.py
@@ -10,6 +10,8 @@ from typing import List
 from app.core.config import get_file_url
 from app.core.db import get_db
 from app.api.deps import get_current_admin_user, get_current_user
+from app.models.notification import Notification
+from app.schemas.notification import NotificationResponse
 
 from app.models.user import User
 from app.schemas.user import ScoreboardEntry
@@ -163,3 +165,18 @@ def get_scoreboard(
              .all()
 
     return users
+
+@router.get("/notifications", response_model=List[NotificationResponse])
+def get_timeline_notifications(
+    db: Session = Depends(get_db),
+    _current_user: User = Depends(get_current_user),
+    limit: int = 20
+):
+    """
+    Fetches the latest global notifications for the player's timeline.
+    """
+    notifications = db.query(Notification) \
+                      .order_by(Notification.created_at.desc()) \
+                      .limit(limit) \
+                      .all()
+    return notifications

--- a/app/models/notification.py
+++ b/app/models/notification.py
@@ -1,0 +1,15 @@
+from datetime import datetime, timezone
+from sqlalchemy import String, Integer, DateTime
+from sqlalchemy.orm import Mapped, mapped_column
+from app.core.db import Base
+
+class Notification(Base):
+    __tablename__ = "notifications"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    content: Mapped[str] = mapped_column(String(280), nullable=False) # 280 character limit at DB level
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, 
+        default=lambda: datetime.now(timezone.utc), 
+        nullable=False
+    )

--- a/app/schemas/notification.py
+++ b/app/schemas/notification.py
@@ -1,0 +1,14 @@
+from datetime import datetime
+from pydantic import BaseModel, Field
+
+class NotificationCreate(BaseModel):
+    # Enforces min 1 char, max 280 chars via Pydantic validation
+    content: str = Field(..., min_length=1, max_length=280, description="The announcement content")
+
+class NotificationResponse(BaseModel):
+    id: int
+    content: str
+    created_at: datetime
+
+    class Config:
+        from_attributes = True

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1,0 +1,65 @@
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.main import app  # Adjust this import to wherever your FastAPI app instance lives
+from app.api.deps import get_current_user, get_current_admin_user
+from app.models.notification import Notification
+from app.models.user import User
+
+# Quick mock generators for authentication dependencies
+def mock_admin_user():
+    return User(id=1, username="admin", is_admin=True, score=0)
+
+def mock_normal_user():
+    return User(id=2, username="player1", is_admin=False, score=0)
+
+
+def test_admin_can_send_notification(client: TestClient, db_session: Session):
+    # Override dependency to simulate an admin login
+    app.dependency_overrides[get_current_admin_user] = mock_admin_user
+    
+    payload = {"content": "System maintenance in 10 minutes!"}
+    response = client.post("/api/v1/admin/notifications", json=payload)
+    
+    # Clean up overrides right away
+    app.dependency_overrides.clear()
+    
+    assert response.status_code == 200
+    data = response.json()
+    assert data["content"] == payload["content"]
+
+
+def test_player_can_receive_notifications(client: TestClient, db_session: Session):
+    app.dependency_overrides[get_current_user] = mock_normal_user
+    
+    # Seed data using the correct 'db_session' fixture name from your logs
+    test_notification = Notification(content="Welcome to NexusFlag v1.0.0!")
+    db_session.add(test_notification)
+    db_session.commit()
+
+    response = client.get("/api/v1/game/notifications")
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert response.json()[0]["content"] == "Welcome to NexusFlag v1.0.0!"
+
+
+def test_player_cannot_send_notification(client: TestClient):
+    app.dependency_overrides[get_current_user] = mock_normal_user
+    
+    payload = {"content": "Hacking attempts..."}
+    response = client.post("/api/v1/admin/notifications", json=payload)
+    
+    app.dependency_overrides.clear()
+    
+    assert response.status_code == 403
+
+def test_notification_character_limit(client: TestClient):
+    app.dependency_overrides[get_current_admin_user] = mock_admin_user
+    
+    payload = {"content": "A" * 281}
+    response = client.post("/api/v1/admin/notifications", json=payload)
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 422


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
New feature - global notification system. This system allows game administrators to send global notifications to all players, within a character limit. Players are always able to see these notifications but not send them, and administrators are always able to send the notifications. These can be used for various purposes, including things like announcing game starts and ends.

* **What is the current behavior?** (You can also link to an open issue here)
Currently there is no notification system in place.

* **What is the new behavior (if this is a feature change)?**
This pull request creates a notification system which allows admins to send notifications.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Yes - it's a breaking issue with data. For changes to become effective database needs to be reseeded.

* **Other information**:
N/A.